### PR TITLE
Fix roster-sync Remove

### DIFF
--- a/src/controllers/controller/controller.ts
+++ b/src/controllers/controller/controller.ts
@@ -30,7 +30,7 @@ import { TrainingWaitlistModel } from '../../models/trainingWaitlist.js';
 import { UserModel, type IUser } from '../../models/user.js';
 import status from '../../types/status.js';
 import absenceRouter from './absence.js';
-import { checkOI, clearUserCache, grantCerts, uploadAvatar } from './utils.js';
+import { checkOI, clearUserCache, grantCerts, syncUserHistory, uploadAvatar } from './utils.js';
 import visitRouter from './visitapplications.js';
 
 const router = Router();
@@ -582,11 +582,16 @@ router.patch(
 				user.certCodes = certDates.map((c) => c.code);
 				user.certificationDate = certDates;
 			} else {
-				user.history.push({
-					start: user.joinDate!,
-					end: new Date(),
-					reason: `Removed from roster by an external service.`,
-				});
+				if (user.joinDate) {
+					user.history.push({
+						start: user.joinDate,
+						end: new Date(),
+						reason: `Removed from roster by an external service.`,
+					});
+				} else {
+					syncUserHistory(user.cid);
+				}
+
 				user.joinDate = null;
 				user.removalDate = new Date();
 				user.oi = '';
@@ -862,11 +867,18 @@ router.delete(
 
 			user.member = false;
 			user.removalDate = new Date();
-			user.history.push({
-				start: user.joinDate!,
-				end: new Date(),
-				reason: req.body.reason,
-			});
+			if (user.joinDate) {
+				user.history.push({
+					start: user.joinDate,
+					end: new Date(),
+					reason: req.body.reason,
+				});
+			} else {
+				// Give VATUSA time to process to the roster removal
+				setTimeout(() => {
+					syncUserHistory(user.cid);
+				}, 30 * 1000);
+			}
 			user.joinDate = null;
 			user.oi = '';
 

--- a/src/controllers/controller/utils.ts
+++ b/src/controllers/controller/utils.ts
@@ -1,8 +1,9 @@
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import { getCacheInstance } from '../../app.js';
 import { throwInternalServerErrorException } from '../../helpers/errors.js';
 import { clearCachePrefix } from '../../helpers/redis.js';
 import { findInS3, uploadToS3 } from '../../helpers/s3.js';
+import { vatusaApi } from '../../helpers/vatusa.js';
 import { UserModel, type ICertificationDate, type IUser } from '../../models/user.js';
 
 export async function checkOI(user: IUser) {
@@ -169,4 +170,84 @@ export async function clearUserCache(id: number) {
 	await getCacheInstance().clear('users');
 	await getCacheInstance().clear('discord-users');
 	await getCacheInstance().clear(`auth-${id}`);
+}
+
+interface IVatusaHistoryResponse {
+	data: IVatusaHistory[];
+	testing: boolean;
+}
+
+interface IVatusaHistory {
+	id: number;
+	cid: number;
+	to: string;
+	from: string;
+	reason: string;
+	status: number;
+	actiontext: string;
+	actionby: number; // CID or 0 for system
+	created_at: Date;
+	updated_at: Date;
+}
+
+export async function syncUserHistory(cid: number) {
+	const user = await UserModel.findOne({ cid }).exec();
+	if (!user) return;
+
+	try {
+		const { data }: AxiosResponse<IVatusaHistoryResponse> = await vatusaApi.get(
+			`user/${cid}/transfer/history`,
+		);
+
+		const history = buildHistory(data.data);
+
+		history.forEach((h) => {
+			if (user.history.find((existing) => existing.start.getTime() === h.start.getTime())) {
+				return;
+			} else {
+				user.history.push(h);
+			}
+		});
+
+		// Ensure history is chronological
+		user.history.sort((a, b) => {
+			return a.end.getTime() - b.end.getTime();
+		});
+
+		await user.save();
+	} catch (e: any) {
+		if (e.name !== 'TimeoutError') {
+			console.error(e);
+		}
+	}
+}
+
+function buildHistory(transfers: any[]) {
+	const history = [];
+	let joinDate = null;
+
+	for (const transfer of transfers.reverse()) {
+		if (transfer.status !== 1) continue;
+
+		if (transfer.to === 'ZAU') {
+			joinDate = new Date(transfer.updated_at);
+		} else {
+			// Assuming transferred out
+			if (joinDate !== null) {
+				history.push({
+					start: joinDate,
+					end: new Date(transfer.updated_at),
+					reason:
+						typeof transfer.reason === 'string'
+							? transfer.reason.includes('reason in log below only')
+								? transfer.actiontext
+								: transfer.reason
+							: transfer.actiontext,
+				});
+				joinDate = null;
+			}
+		}
+	}
+
+	return history;
 }

--- a/src/controllers/discord/bot.ts
+++ b/src/controllers/discord/bot.ts
@@ -244,6 +244,11 @@ router.put(
 				actionType: ACTION_TYPE.UPDATE_DISCORD_CONFIG,
 			});
 
+			await req.app.redis
+				.lpush('config_update', id)
+				.then(() => console.log('Task sent to queue', id))
+				.catch((err) => console.error('Error sending config_update task', err));
+
 			return res.status(status.OK).json();
 		} catch (e) {
 			return next(e);


### PR DESCRIPTION
roster-sync was failing to remove users if the user's `joinDate` was not set. In theory, this should not happen, however there appears to be some users where the field is not set. If we come across one of those, we will pull their history from VATUSA and populate the array appropriately.