### PR TITLE
Prevent VATUSA from creating duplicate solo endorsements

### DIFF
--- a/src/controllers/training/soloendorsements.ts
+++ b/src/controllers/training/soloendorsements.ts
@@ -101,17 +101,13 @@ router.post(
 				throwBadRequestException('Solo endorsements cannot be issued for more than 45 days');
 			}
 
-			let vatusaId = 0;
 			if (zau.isProd) {
 				try {
-					const { data: vatusaResponse } = await vatusaApi.post('/solo', {
+					await vatusaApi.post('/solo', {
 						cid: student.cid,
 						position: req.body.position,
 						expDate: DateTime.fromJSDate(endDate).toUTC().toFormat('yyyy-MM-dd'),
 					});
-					vatusaId = vatusaResponse.data.id || 0;
-
-					console.log('vatusa solo endorsement id', vatusaId, vatusaResponse.data);
 				} catch (err) {
 					throwInternalServerErrorException(
 						(err as any).response?.data?.data?.msg || 'Error posting to VATUSA',
@@ -123,7 +119,7 @@ router.post(
 				studentCid: student.cid,
 				instructorCid: req.user.cid,
 				position: req.body.position,
-				vatusaId: vatusaId,
+				vatusaId: 0, // VATUSA does not return any data during creation.
 				expires: endDate,
 			});
 
@@ -213,12 +209,12 @@ router.patch(
 				}
 
 				try {
-					const { data: vatusaResponse } = await vatusaApi.post('/solo', {
+					await vatusaApi.post('/solo', {
 						cid: solo.studentCid,
 						position: solo.position,
 						expDate: DateTime.fromJSDate(newEndDate).toUTC().toFormat('yyyy-MM-dd'),
 					});
-					solo.vatusaId = vatusaResponse.data.id || 0;
+					solo.vatusaId = 0; // VATUSA does not return any data during creation.
 				} catch (err) {
 					e += `\n${err}`;
 				}

--- a/src/tasks/solo.ts
+++ b/src/tasks/solo.ts
@@ -55,12 +55,31 @@ export async function syncVatusaSoloEndorsements() {
 			const facility = solo.position.slice(0, 3);
 			if (!ZAU_FACILITIES.includes(facility)) continue;
 
-			const ours = await SoloEndorsementModel.findOne({ vatusaId: solo.id }).exec();
-			if (ours) {
-				if (ours.expires.getTime() === new Date(solo.expires).getTime()) continue;
+			const match = await SoloEndorsementModel.findOne({ vatusaId: solo.id }).exec();
+			if (match) {
+				if (match.expires.getTime() !== new Date(solo.expires).getTime()) {
+					match.expires = new Date(solo.expires);
+					await match.save();
+				}
 
-				ours.expires = new Date(solo.expires);
-				await ours.save();
+				continue;
+			}
+
+			const minDate = new Date(new Date(solo.created_at).getTime() - 10_000);
+			const maxDate = new Date(new Date(solo.created_at).getTime() + 10_000);
+
+			const exists = await SoloEndorsementModel.findOne({
+				studentCid: solo.cid,
+				vatusaId: 0,
+				createdAt: {
+					$lte: maxDate,
+					$gte: minDate,
+				},
+			}).exec();
+			if (exists) {
+				exists.vatusaId = solo.id;
+				exists.expires = new Date(solo.expires);
+				await exists.save();
 
 				continue;
 			}


### PR DESCRIPTION
Closes #252 

VATUSA does not provide its internal ID (or any data for that matter (see [vatusa/api](https://github.com/VATUSA/api/blob/b2507f57588423be420d4bb56f7e20315cf351c7/app/Http/Controllers/API/v2/SoloController.php#L166))) when a solo endorsement is created via the API. Thus, we are duplicating Solo Endorsements that we submit.

To fix this, we will check that the student matches, and the issue time of the endorsement is within a tight 10 second window, which allows for differences in the latency of the VATUSA API. This check will prevent us from creating a new entry for an existing solo endorsement.