### PR TITLE
sync vatusa data on login

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -73,7 +73,7 @@ app.redis.on('connect', () => {
 console.log('Connecting to cache instance. . . .');
 const redisCache = new Redis(`${MONGO_CACHE_URI}?family=4&connectionName=cache`);
 redisCache.on('error', (err) => {
-	throw new Error(`Redis error: ${err}.`);
+	throw new Error(`Cache Redis error: ${err}.`);
 });
 redisCache.on('connect', () => {
 	console.log('Successfully connected to Redis Cache');
@@ -89,7 +89,6 @@ if (!CORS_ORIGIN) {
 }
 const origins = CORS_ORIGIN.split('|');
 
-console.log('Allowing CORS origins. . . .');
 app.use(
 	cors({
 		origin: origins,

--- a/src/controllers/user/user.ts
+++ b/src/controllers/user/user.ts
@@ -508,7 +508,7 @@ interface IVATUSAUser {
 }
 
 async function syncController(user: IUser) {
-	if (!zau.isDev) return;
+	if (zau.isDev) return;
 
 	try {
 		const { data } = await vatusaApi.get(`/user/${user.cid}`);

--- a/src/controllers/user/user.ts
+++ b/src/controllers/user/user.ts
@@ -10,6 +10,7 @@ import {
 	throwUnauthorizedException,
 } from '../../helpers/errors.js';
 import { clearCachePrefix } from '../../helpers/redis.js';
+import { vatusaApi } from '../../helpers/vatusa.js';
 import zau from '../../helpers/zau.js';
 import { userOrInternal } from '../../middleware/auth.js';
 import internalAuth from '../../middleware/internalAuth.js';
@@ -19,7 +20,7 @@ import { ControllerHoursModel } from '../../models/controllerHours.js';
 import { ACTION_TYPE, DossierModel } from '../../models/dossier.js';
 import { NotificationModel } from '../../models/notification.js';
 import { TrainingSessionModel } from '../../models/trainingSession.js';
-import { UserModel } from '../../models/user.js';
+import { UserModel, type IUser } from '../../models/user.js';
 import status from '../../types/status.js';
 import { clearUserCache } from '../controller/utils.js';
 import gdrpRouter from './gdrp.js';
@@ -220,20 +221,10 @@ router.post('/login', oAuth, async (req: Request, res: Response, next: NextFunct
 				member: false,
 				vis: false,
 			});
-		} else {
-			if (!user.email || user.email !== userData.email) {
-				user.email = userData.email;
-			}
-			if (!user.fname || user.lname !== userData.firstName) {
-				user.fname = userData.firstName;
-			}
-			if (!user.lname || user.lname !== userData.lastName) {
-				user.lname = userData.lastName;
-			}
-			user.rating = userData.ratingId;
 		}
 
-		await user.save();
+		syncController(user).catch((err) => console.error('Uncaught error in VATUSA user sync', err));
+
 		clearUserCache(user.cid);
 
 		const apiToken = jwt.sign({ cid: userData.cid }, process.env['JWT_SECRET']!, {
@@ -475,3 +466,84 @@ router.patch('/:cid', internalAuth, async (req: Request, res: Response, next: Ne
 });
 
 export default router;
+
+interface IVATUSAUser {
+	cid: number;
+	fname: string;
+	lname: string;
+	email: string;
+	facility: string;
+	rating: number;
+	rating_short: string;
+	rating_long: string;
+	created_at: string; // ISO Date
+	updated_at: string; // ISO Date
+	flag_needbasic: boolean;
+	flag_xferOverride: boolean;
+	flag_broadcastOptedIn: boolean;
+	flag_preventStaffAssign: null;
+	flag_nameprivacy: boolean;
+	facility_join: string;
+	promotion_eligible: boolean;
+	transfer_eligible: null;
+	last_promotion: string; // ISO Date
+	flag_homeController: boolean;
+	lastactivity: string; // ISO Date
+	isMentor: boolean;
+	isSupIns: boolean;
+	roles: {
+		id: number;
+		cid: number;
+		facility: string;
+		role: string;
+		created_at: string; // ISO Date
+	}[];
+	visiting_facilities: {
+		id: number;
+		cid: number;
+		facility: string;
+		created_at: string; // ISO Date
+		updated_at: string; // ISO Date
+	}[];
+}
+
+async function syncController(user: IUser) {
+	if (!zau.isDev) return;
+
+	try {
+		const { data } = await vatusaApi.get(`/user/${user.cid}`);
+
+		const vatusa = data.data as IVATUSAUser;
+
+		if (vatusa.fname !== user.fname) {
+			user.fname = vatusa.fname;
+		}
+		if (vatusa.lname !== user.lname) {
+			user.lname = vatusa.lname;
+		}
+		if (vatusa.email !== user.email) {
+			user.email = vatusa.email;
+		}
+		if (vatusa.rating !== user.rating) {
+			user.rating = vatusa.rating;
+		}
+		if (vatusa.flag_nameprivacy !== user.prefName) {
+			user.prefName = vatusa.flag_nameprivacy;
+		}
+		if (vatusa.facility !== user.homeFacility) {
+			user.homeFacility = vatusa.facility;
+		}
+		if (vatusa.facility === 'ZAU' && !user.member) {
+			user.member = true;
+		}
+		if (vatusa.visiting_facilities.some((f) => f.facility === 'ZAU') && !user.vis) {
+			user.vis = true;
+		}
+
+		if (user.isModified()) {
+			console.log('Updating', user.cid, 'with VATUSA data.');
+		}
+	} catch (e) {
+		console.warn('Failed to fetch VATUSA details for', user.cid, 'during login.');
+	}
+}


### PR DESCRIPTION
Instead of only using the VATSIM data provided during the access token exchange, get the user details from the VATUSA API. Currently, only rostered users get the completely updated information via roster-sync. This will update all users when they log in.